### PR TITLE
Introduces the `Queryable` a Macro

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/MacroTests.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/MacroTests.xcscheme
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1510"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "MacroTests"
+               BuildableName = "MacroTests"
+               BlueprintName = "MacroTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/QueryableKit-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/QueryableKit-Package.xcscheme
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1510"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirestoreQueryable"
+               BuildableName = "FirestoreQueryable"
+               BlueprintName = "FirestoreQueryable"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "QueryableCore"
+               BuildableName = "QueryableCore"
+               BlueprintName = "QueryableCore"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CoreTests"
+               BuildableName = "CoreTests"
+               BlueprintName = "CoreTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirestoreTests"
+               BuildableName = "FirestoreTests"
+               BlueprintName = "FirestoreTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "MacroTests"
+               BuildableName = "MacroTests"
+               BlueprintName = "MacroTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CoreTests"
+               BuildableName = "CoreTests"
+               BlueprintName = "CoreTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FirestoreTests"
+               BuildableName = "FirestoreTests"
+               BlueprintName = "FirestoreTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "MacroTests"
+               BuildableName = "MacroTests"
+               BlueprintName = "MacroTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FirestoreQueryable"
+            BuildableName = "FirestoreQueryable"
+            BlueprintName = "FirestoreQueryable"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Package.resolved
+++ b/Package.resolved
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax",
       "state" : {
-        "revision" : "6ad4ea24b01559dde0773e3d091f1b9e36175036",
-        "version" : "509.0.2"
+        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
+        "version" : "509.1.1"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -107,6 +107,15 @@
         "revision" : "cf62cdaea48b77f1a631e5cb3aeda6047c2cba1d",
         "version" : "1.23.0"
       }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-syntax",
+      "state" : {
+        "revision" : "6ad4ea24b01559dde0773e3d091f1b9e36175036",
+        "version" : "509.0.2"
+      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,7 @@
 // swift-tools-version: 5.9
 
 import PackageDescription
+import CompilerPluginSupport
 
 let package = Package(
     name: "QueryableKit",
@@ -15,12 +16,13 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/firebase/firebase-ios-sdk", from: .init(10, 0, 0))
+        .package(url: "https://github.com/firebase/firebase-ios-sdk", from: .init(10, 14, 0)),
+        .package(url: "https://github.com/apple/swift-syntax", from: "509.0.0")
     ],
     targets: [
         .target(
             name: "QueryableCore",
-            dependencies: [],
+            dependencies: ["QueryableMacros"],
             path: "Sources/Core"
         ),
         .target(
@@ -36,6 +38,18 @@ let package = Package(
                 .linkedLibrary("c++"),
             ]
         ),
+
+        // MARK: Macro
+        .macro(
+            name: "QueryableMacros",
+            dependencies: [
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax")
+            ],
+            path: "Sources/Macro"
+        ),
+        
+        // MARK: Tests
         .testTarget(
             name: "CoreTests",
             dependencies: ["QueryableCore"]
@@ -44,6 +58,13 @@ let package = Package(
             name: "FirestoreTests",
             dependencies: ["FirestoreQueryable"],
             resources: [.copy("secrets/secrets.json")]
-        )
+        ),
+        .testTarget(
+            name: "MacroTests",
+            dependencies: [
+                "QueryableMacros",
+                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
+            ]
+        ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/firebase/firebase-ios-sdk", from: .init(10, 14, 0)),
-        .package(url: "https://github.com/apple/swift-syntax", from: "509.0.0")
+        .package(url: "https://github.com/apple/swift-syntax", from: "509.1.1")
     ],
     targets: [
         .target(

--- a/Sources/Core/Misc/Errors.swift
+++ b/Sources/Core/Misc/Errors.swift
@@ -44,7 +44,7 @@ public struct TypeNotSupported: Error, LocalizedError {
     }
 }
 
-public struct FieldMissing<Model: Queryable>: Error, LocalizedError {
+public struct FieldMissing<Model: QueryableModel>: Error, LocalizedError {
     let key: PartialKeyPath<Model>
     
     public var localizedDescription: String {

--- a/Sources/Core/Operators/Field.swift
+++ b/Sources/Core/Operators/Field.swift
@@ -1,6 +1,6 @@
-/// A `Field`  defines a predicate that can be used to compare a `Queryable` key path
+/// A `Field`  defines a predicate that can be used to compare a `QueryableModel` key path
 /// to a `Value` with a specified `Operator`.
-public struct Field<Root: Queryable, RootValue, Value> {
+public struct Field<Root: QueryableModel, RootValue, Value> {
     
     public enum Operator: String {
         case isEqualTo

--- a/Sources/Core/Operators/Limit.swift
+++ b/Sources/Core/Operators/Limit.swift
@@ -13,7 +13,7 @@ public struct Limit: QueryablePredicate {
     }
 }
 
-extension Never: Queryable {
+extension Never: QueryableModel {
     public static func field(_ path: PartialKeyPath<Never>) -> String? { nil }
     
     public init(from decoder: Decoder) throws {

--- a/Sources/Core/Operators/Sort.swift
+++ b/Sources/Core/Operators/Sort.swift
@@ -1,7 +1,7 @@
-/// A `Sort`  defines a predicate for sorting condition on `Queryable` object keyPath.
+/// A `Sort`  defines a predicate for sorting condition on `QueryableModel` object keyPath.
 ///
 /// It also provides a way to define `ascending` or `descending` order.
-public struct Sort<Root: Queryable, Value: Comparable>: QueryablePredicate {
+public struct Sort<Root: QueryableModel, Value: Comparable>: QueryablePredicate {
     public let keyPath: KeyPath<Root, Value>
     public let descending: Bool
     

--- a/Sources/Core/QueryPredicate.swift
+++ b/Sources/Core/QueryPredicate.swift
@@ -1,6 +1,6 @@
 /// A `QueryablePredicate` provides a type-safe way to represent a condition
 /// that can be used to filter, sort and query your data.
-public protocol QueryablePredicate<Model> where Model: Queryable  {
+public protocol QueryablePredicate<Model> where Model: QueryableModel {
     associatedtype Model
     
     /// A `PartialKeyPath` that identifies the property of the `Model` that the predicate applies to.

--- a/Sources/Core/Queryable+Macro.swift
+++ b/Sources/Core/Queryable+Macro.swift
@@ -1,0 +1,7 @@
+import QueryableMacros
+
+/// The `Queryable` macro defines a type that can be queried
+/// using predicates conforming to the `QueryablePredicate` protocol.
+@attached(member, names: named(field))
+@attached(extension, conformances: QueryableModel)
+public macro Queryable() = #externalMacro(module: "QueryableMacros", type: "QueryableMacro")

--- a/Sources/Core/QueryableModel.swift
+++ b/Sources/Core/QueryableModel.swift
@@ -1,6 +1,6 @@
-/// The `Queryable` protocol defines a type that can be queried
+/// The `QueryableModel` protocol defines a type that can be queried
 /// using predicates conforming to the `QueryablePredicate` protocol.
-public protocol Queryable: Codable {
+public protocol QueryableModel: Codable {
     
     /// Returns the string path that corresponds to the provided key path, if one exists.
     ///

--- a/Sources/Macro/Member+Extension/DeclGroupSyntax.swift
+++ b/Sources/Macro/Member+Extension/DeclGroupSyntax.swift
@@ -1,0 +1,32 @@
+import SwiftSyntax
+
+extension DeclGroupSyntax {
+    var varNames: [TokenSyntax] {
+        memberBlock.members
+            .compactMap {
+                $0.decl.as(VariableDeclSyntax.self)
+            }.flatMap {
+                $0.bindings.compactMap {
+                    $0.pattern.as(IdentifierPatternSyntax.self)?.identifier
+                }
+            }
+    }
+    
+    func casesNameOfEnum<T>(conformingTo enumType: T.Type) -> [TokenSyntax]? {
+        memberBlock.members
+            .first(where: {
+                guard
+                    let enumDecl = $0.decl.as(EnumDeclSyntax.self),
+                    let types = enumDecl.inheritanceClause?.inheritedTypes
+                else { return false }
+                
+                return types.contains { $0.type.as(IdentifierTypeSyntax.self)?.name.text == "\(enumType.self)" }
+            })?
+            .as(MemberBlockItemSyntax.self)?
+            .decl.as(EnumDeclSyntax.self)?
+            .memberBlock.members
+            .compactMap {
+                $0.decl.as(EnumCaseDeclSyntax.self)?.elements.first?.name.trimmed
+            }
+    }
+}

--- a/Sources/Macro/QueryableMacro.swift
+++ b/Sources/Macro/QueryableMacro.swift
@@ -2,42 +2,40 @@ import SwiftSyntax
 import SwiftSyntaxMacros
 import SwiftCompilerPlugin
 
-
 public struct QueryableMacro: MemberMacro {
     
     static let backslashToken = TokenSyntax.backslashToken()
-        
+    
     public static func expansion(
         of node: AttributeSyntax,
         providingMembersOf declaration: some DeclGroupSyntax,
+        conformingTo protocols: [TypeSyntax],
         in context: some MacroExpansionContext
     ) throws -> [DeclSyntax] {
-        guard let structure = declaration.as(StructDeclSyntax.self) else { return [] }
+        var propertiesToMap = declaration.varNames
         
-        let variables = structure.memberBlock.members.compactMap {
-            $0.decl.as(VariableDeclSyntax.self)
-        }
-        
-        let identifiers = variables.flatMap {
-            $0.bindings.compactMap { $0.pattern.as(IdentifierPatternSyntax.self)?.identifier }
+        if let codingKeys = declaration.casesNameOfEnum(conformingTo: CodingKey.self) {
+            propertiesToMap.removeAll(where: { structProp in
+                !codingKeys.contains(where: { $0.text == structProp.text })
+            })
         }
         
         /// Returns the string path associated to the provided key path, if one exists.
         ///
         /// - Parameter path: The key path to convert to a string path.
         /// - Returns: The string path that corresponds to the provided key path, or `nil` if the key path cannot be converted to a string path.
-                
+        
         let new = try FunctionDeclSyntax("static func field(_ path: PartialKeyPath<Self>) -> String?") {
             """
             switch path {
-            \(raw: identifiers.map({ token in
+            \(raw: propertiesToMap.map({ token in
                 "case \(backslashToken).\(token): return CodingKeys.\(token).stringValue"
             }).joined(separator: "\n"))
             default: return nil
             }
             """
         }
-                
+        
         return [
             DeclSyntax(new)
         ]

--- a/Sources/Macro/QueryableMacro.swift
+++ b/Sources/Macro/QueryableMacro.swift
@@ -29,7 +29,7 @@ public struct QueryableMacro: MemberMacro {
             $0.bindings.compactMap { $0.pattern.as(IdentifierPatternSyntax.self)?.identifier }
         }
         
-        /// Returns the string path that corresponds to the provided key path, if one exists.
+        /// Returns the string path associated to the provided key path, if one exists.
         ///
         /// - Parameter path: The key path to convert to a string path.
         /// - Returns: The string path that corresponds to the provided key path, or `nil` if the key path cannot be converted to a string path.
@@ -44,12 +44,24 @@ public struct QueryableMacro: MemberMacro {
             }
             """
         }
-        
+                
         return [
             DeclSyntax(new)
         ]
     }
-    
+}
+
+extension QueryableMacro: ExtensionMacro {
+    public static func expansion(
+        of node: SwiftSyntax.AttributeSyntax,
+        attachedTo declaration: some SwiftSyntax.DeclGroupSyntax,
+        providingExtensionsOf type: some SwiftSyntax.TypeSyntaxProtocol,
+        conformingTo protocols: [SwiftSyntax.TypeSyntax],
+        in context: some SwiftSyntaxMacros.MacroExpansionContext
+    ) throws -> [SwiftSyntax.ExtensionDeclSyntax] {
+        let equatableExtension = try ExtensionDeclSyntax("extension \(type.trimmed): QueryableModel {}")
+        return [equatableExtension]
+    }
 }
 
 

--- a/Sources/Macro/QueryableMacro.swift
+++ b/Sources/Macro/QueryableMacro.swift
@@ -1,0 +1,61 @@
+import SwiftSyntax
+import SwiftSyntaxMacros
+import SwiftCompilerPlugin
+
+//import QueryableMacros
+//
+//@attached(member)
+///// The `Queryable` macro defines a type that can be queried
+///// using predicates conforming to the `QueryablePredicate` protocol.
+//public macro Queryable() = #externalMacro(module: "QueryableMacros", type: "QueryableMacro")
+
+
+public struct QueryableMacro: MemberMacro {
+    
+    static let backslashToken = TokenSyntax.backslashToken()
+        
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingMembersOf declaration: some DeclGroupSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        guard let structure = declaration.as(StructDeclSyntax.self) else { return [] }
+        
+        let variables = structure.memberBlock.members.compactMap {
+            $0.decl.as(VariableDeclSyntax.self)
+        }
+        
+        let identifiers = variables.flatMap {
+            $0.bindings.compactMap { $0.pattern.as(IdentifierPatternSyntax.self)?.identifier }
+        }
+        
+        /// Returns the string path that corresponds to the provided key path, if one exists.
+        ///
+        /// - Parameter path: The key path to convert to a string path.
+        /// - Returns: The string path that corresponds to the provided key path, or `nil` if the key path cannot be converted to a string path.
+                
+        let new = try FunctionDeclSyntax("static func field(_ path: PartialKeyPath<Self>) -> String?") {
+            """
+            switch path {
+            \(raw: identifiers.map({ token in
+                "case \(backslashToken).\(token): return CodingKeys.\(token).stringValue"
+            }).joined(separator: "\n"))
+            default: return nil
+            }
+            """
+        }
+        
+        return [
+            DeclSyntax(new)
+        ]
+    }
+    
+}
+
+
+@main
+struct QueryablePlugin: CompilerPlugin {
+    let providingMacros: [Macro.Type] = [
+        QueryableMacro.self,
+    ]
+}

--- a/Sources/Macro/QueryableMacro.swift
+++ b/Sources/Macro/QueryableMacro.swift
@@ -2,13 +2,6 @@ import SwiftSyntax
 import SwiftSyntaxMacros
 import SwiftCompilerPlugin
 
-//import QueryableMacros
-//
-//@attached(member)
-///// The `Queryable` macro defines a type that can be queried
-///// using predicates conforming to the `QueryablePredicate` protocol.
-//public macro Queryable() = #externalMacro(module: "QueryableMacros", type: "QueryableMacro")
-
 
 public struct QueryableMacro: MemberMacro {
     
@@ -53,12 +46,12 @@ public struct QueryableMacro: MemberMacro {
 
 extension QueryableMacro: ExtensionMacro {
     public static func expansion(
-        of node: SwiftSyntax.AttributeSyntax,
-        attachedTo declaration: some SwiftSyntax.DeclGroupSyntax,
-        providingExtensionsOf type: some SwiftSyntax.TypeSyntaxProtocol,
-        conformingTo protocols: [SwiftSyntax.TypeSyntax],
-        in context: some SwiftSyntaxMacros.MacroExpansionContext
-    ) throws -> [SwiftSyntax.ExtensionDeclSyntax] {
+        of node: AttributeSyntax,
+        attachedTo declaration: some DeclGroupSyntax,
+        providingExtensionsOf type: some TypeSyntaxProtocol,
+        conformingTo protocols: [TypeSyntax],
+        in context: some MacroExpansionContext
+    ) throws -> [ExtensionDeclSyntax] {
         let equatableExtension = try ExtensionDeclSyntax("extension \(type.trimmed): QueryableModel {}")
         return [equatableExtension]
     }

--- a/Tests/CoreTests/CoreTests.swift
+++ b/Tests/CoreTests/CoreTests.swift
@@ -24,13 +24,24 @@ struct City: QueryableModel, Equatable {
     }
 }
 
+@Queryable
+struct Person {
+    let name: String
+    let age: Int
+    let friendsIds: [Int]
+}
+
 final class QueryableTests: XCTestCase {
-    func test_givenFieldHasBeenSpecified_then_fieldMethod_mustReturnsExpectedValue() throws {
+    func test_whenFieldExists_mustReturnExpectedName() throws {
         XCTAssertEqual(try Field(\City.name, isEqualTo: "").field(), "name")
         XCTAssertEqual(try Field(\City.population, isGreaterThanOrEqualTo: 0).field(), "populationCount")
+        
+        XCTAssertEqual(try Field(\Person.name, isEqualTo: "").field(), "name")
+        XCTAssertEqual(try Field(\Person.age, isEqualTo: 0).field(), "age")
+        XCTAssertEqual(try Field(\Person.friendsIds, contains: 0).field(), "friendsIds")
     }
     
-    func test_givenMissingPath_then_fieldMethod_mustThrownException() throws {
+    func test_whenFieldIsMissing_mustThrow_FieldMissing() throws {
         XCTAssertThrowsError(try Field(\City.missingField, isEqualTo: false).field()) { error in
             print(error.localizedDescription)
             let error = try! XCTUnwrap(error as? FieldMissing<City>)

--- a/Tests/CoreTests/CoreTests.swift
+++ b/Tests/CoreTests/CoreTests.swift
@@ -1,26 +1,18 @@
 import XCTest
 @testable import QueryableCore
 
-struct City: QueryableModel, Equatable {
+@Queryable
+struct City: Equatable {
     let name: String
     let population: Int
     let suburbs: [String]
     
-    let missingField: Bool = false
+    let mustNotBeMapped: Bool = false
     
     enum CodingKeys: String, CodingKey {
         case name
         case population = "populationCount"
         case suburbs
-    }
-    
-    static func field(_ path: PartialKeyPath<City>) -> String? {
-        switch path {
-        case \.name: return CodingKeys.name.stringValue
-        case \.population: return CodingKeys.population.stringValue
-        case \.suburbs: return CodingKeys.suburbs.stringValue
-        default: return nil
-        }
     }
 }
 
@@ -42,10 +34,10 @@ final class QueryableTests: XCTestCase {
     }
     
     func test_whenFieldIsMissing_mustThrow_FieldMissing() throws {
-        XCTAssertThrowsError(try Field(\City.missingField, isEqualTo: false).field()) { error in
+        XCTAssertThrowsError(try Field(\City.mustNotBeMapped, isEqualTo: false).field()) { error in
             print(error.localizedDescription)
             let error = try! XCTUnwrap(error as? FieldMissing<City>)
-            XCTAssertEqual(error.key, \.missingField)
+            XCTAssertEqual(error.key, \.mustNotBeMapped)
         }
     }
 }

--- a/Tests/CoreTests/CoreTests.swift
+++ b/Tests/CoreTests/CoreTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import QueryableCore
 
-struct City: Queryable, Equatable {
+struct City: QueryableModel, Equatable {
     let name: String
     let population: Int
     let suburbs: [String]

--- a/Tests/FirestoreTests/FirestoreIntegrationTests.swift
+++ b/Tests/FirestoreTests/FirestoreIntegrationTests.swift
@@ -5,22 +5,13 @@ import FirebaseFirestore
 import FirebaseCore
 @testable import FirestoreQueryable
 
-struct Person: QueryableModel {
+@Queryable
+struct Person {
     let id: String
     let name: String
     let cityId: String
     let friendIds: [String]
     let age: Int?
-    
-    static func field(_ path: PartialKeyPath<Person>) -> String? {
-        switch path {
-        case \.name: return CodingKeys.name.stringValue
-        case \.cityId: return CodingKeys.cityId.stringValue
-        case \.friendIds: return CodingKeys.friendIds.stringValue
-        case \.age: return CodingKeys.age.stringValue
-        default: return nil
-        }
-    }
 }
 
 struct FirebaseLoader {

--- a/Tests/FirestoreTests/FirestoreIntegrationTests.swift
+++ b/Tests/FirestoreTests/FirestoreIntegrationTests.swift
@@ -5,7 +5,7 @@ import FirebaseFirestore
 import FirebaseCore
 @testable import FirestoreQueryable
 
-struct Person: Queryable {
+struct Person: QueryableModel {
     let id: String
     let name: String
     let cityId: String

--- a/Tests/MacroTests/MacroTests.swift
+++ b/Tests/MacroTests/MacroTests.swift
@@ -37,6 +37,9 @@ final class MyMacroTests: XCTestCase {
                     }
                 }
             }
+            
+            extension Some: QueryableModel {
+            }
             """,
             macros: testMacros
         )

--- a/Tests/MacroTests/MacroTests.swift
+++ b/Tests/MacroTests/MacroTests.swift
@@ -1,0 +1,49 @@
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+#if canImport(QueryableMacro)
+@testable import QueryableMacros
+
+let testMacros: [String: Macro.Type] = [
+    "Queryable": QueryableMacro.self,
+]
+#endif
+
+final class MyMacroTests: XCTestCase {
+    func testExpansionProcudesExpectedOutput() throws {
+#if canImport(QueryableMacro)
+        assertMacroExpansion(
+            """
+            @Queryable
+            struct Some: Codable {
+                let age: Int
+                let firstName: String
+            }
+            """,
+            expandedSource: """
+            struct Some: Codable {
+                let age: Int
+                let firstName: String
+            
+                static func field(_ path: PartialKeyPath<Self>) -> String? {
+                    switch path {
+                    case \(QueryableMacro.backslashToken).age:
+                        return CodingKeys.age.stringValue
+                    case \(QueryableMacro.backslashToken).firstName:
+                        return CodingKeys.firstName.stringValue
+                    default:
+                        return nil
+                    }
+                }
+            }
+            """,
+            macros: testMacros
+        )
+#else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+#endif
+    }
+
+}
+

--- a/Tests/MacroTests/MacroTests.swift
+++ b/Tests/MacroTests/MacroTests.swift
@@ -2,36 +2,40 @@ import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
 import XCTest
 
-#if canImport(QueryableMacro)
 @testable import QueryableMacros
 
 let testMacros: [String: Macro.Type] = [
     "Queryable": QueryableMacro.self,
 ]
-#endif
+
+let backslash = QueryableMacro.backslashToken
 
 final class MyMacroTests: XCTestCase {
-    func testExpansionProcudesExpectedOutput() throws {
-#if canImport(QueryableMacro)
+    
+    func test_givenModelWithNoCustomCodingKeys_allPropertiesMustBeAddedInField() throws {
         assertMacroExpansion(
             """
             @Queryable
-            struct Some: Codable {
+            struct Some {
                 let age: Int
                 let firstName: String
+                var isLoggedIn: Bool = false
             }
             """,
             expandedSource: """
-            struct Some: Codable {
+            struct Some {
                 let age: Int
                 let firstName: String
+                var isLoggedIn: Bool = false
             
                 static func field(_ path: PartialKeyPath<Self>) -> String? {
                     switch path {
-                    case \(QueryableMacro.backslashToken).age:
+                    case \(backslash).age:
                         return CodingKeys.age.stringValue
-                    case \(QueryableMacro.backslashToken).firstName:
+                    case \(backslash).firstName:
                         return CodingKeys.firstName.stringValue
+                    case \(backslash).isLoggedIn:
+                        return CodingKeys.isLoggedIn.stringValue
                     default:
                         return nil
                     }
@@ -43,9 +47,6 @@ final class MyMacroTests: XCTestCase {
             """,
             macros: testMacros
         )
-#else
-        throw XCTSkip("macros are only supported when running tests for the host platform")
-#endif
     }
 
 }


### PR DESCRIPTION
To simplify the process of mapping the properties to the expected name, we are introducing the `Queryable` macro, which will automatically synthesise the `static func field(_ path: PartialKeyPath<Self>) -> String?`.

If a model contains a custom `CodingKey` implementation that will be used to filter out the properties that will be mapped.

## Example

```swift
@Queryable
struct City: Equatable {
    let name: String
    let population: Int
    let suburbs: [String]
    
    let mustNotBeMapped: Bool = false
    
    enum CodingKeys: String, CodingKey {
        case name
        case population = "populationCount"
        case suburbs
    }
}
```

will produce:

```swift
struct City: Equatable {
    let name: String
    let population: Int
    let suburbs: [String]
    
    let mustNotBeMapped: Bool = false
    
    enum CodingKeys: String, CodingKey {
        case name
        case population = "populationCount"
        case suburbs
    }
    
    static func field(_ path: PartialKeyPath<Self>) -> String? {
        switch path {
        case \(backslash).name:
            return CodingKeys.name.stringValue
        case \(backslash).population:
            return CodingKeys.population.stringValue
        case \(backslash).suburbs:
            return CodingKeys.suburbs.stringValue
        default:
            return nil
        }
    }
}

extension City: QueryableModel {
}
```

